### PR TITLE
DRAFT: Set publisher & subscriber in google cloud

### DIFF
--- a/image_generator/image_publish/publish_generated_image.py
+++ b/image_generator/image_publish/publish_generated_image.py
@@ -1,0 +1,38 @@
+"""Publishes multiple messages to a Pub/Sub topic with an error handler."""
+from concurrent import futures
+from google.cloud import pubsub_v1
+from typing import Callable
+
+
+# TODO(developer)
+project_id = "omnithink"
+topic_id = "image_generation"
+
+publisher = pubsub_v1.PublisherClient()
+topic_path = publisher.topic_path(project_id, topic_id)
+publish_futures = []
+
+def get_callback(
+    publish_future: pubsub_v1.publisher.futures.Future, data: str
+) -> Callable[[pubsub_v1.publisher.futures.Future], None]:
+    def callback(publish_future: pubsub_v1.publisher.futures.Future) -> None:
+        try:
+            # Wait 60 seconds for the publish call to succeed.
+            print(publish_future.result(timeout=60))
+        except futures.TimeoutError:
+            print(f"Publishing {data} timed out.")
+
+    return callback
+
+for i in range(10):
+    data = str(i)
+    # When you publish a message, the client returns a future.
+    publish_future = publisher.publish(topic_path, data.encode("utf-8"))
+    # Non-blocking. Publish failures are handled in the callback function.
+    publish_future.add_done_callback(get_callback(publish_future, data))
+    publish_futures.append(publish_future)
+
+# Wait for all the publish futures to resolve before exiting.
+futures.wait(publish_futures, return_when=futures.ALL_COMPLETED)
+
+print(f"Published messages with error handler to {topic_path}.")

--- a/image_server/image_consumer/image_consumer.py
+++ b/image_server/image_consumer/image_consumer.py
@@ -1,0 +1,30 @@
+from concurrent.futures import TimeoutError
+from google.cloud import pubsub_v1
+
+# TODO(developer)
+project_id = "omnithink"
+subscription_id = "image_generation-sub"
+# Number of seconds the subscriber should listen for messages
+timeout = 10.0
+
+subscriber = pubsub_v1.SubscriberClient()
+# The `subscription_path` method creates a fully qualified identifier
+# in the form `projects/{project_id}/subscriptions/{subscription_id}`
+subscription_path = subscriber.subscription_path(project_id, subscription_id)
+
+def callback(message: pubsub_v1.subscriber.message.Message) -> None:
+    print(f"Received {message}.")
+    message.ack()
+
+streaming_pull_future = subscriber.subscribe(subscription_path, callback=callback)
+print(f"Listening for messages on {subscription_path}..\n")
+
+# Wrap subscriber in a 'with' block to automatically call close() when done.
+with subscriber:
+    try:
+        # When `timeout` is not set, result() will block indefinitely,
+        # unless an exception is encountered first.
+        streaming_pull_future.result(timeout=timeout)
+    except TimeoutError:
+        streaming_pull_future.cancel()  # Trigger the shutdown.
+        streaming_pull_future.result()  # Block until the shutdown is complete.


### PR DESCRIPTION
This Pull Request introduces the implementation of Google Cloud Pub/Sub for both publishing and subscribing within our application. The implementation enables our application to asynchronously send messages (publish) and receive (subscribe) messages from a specified Pub/Sub topic.

